### PR TITLE
Fix/nodejs requires

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-import axios       from 'axios'
-import pluralize   from 'pluralize'
-import {Promise}   from 'es6-promise'
-import deserialize from './middleware/json-api/_deserialize'
-import serialize   from './middleware/json-api/_serialize'
+const axios = require('axios')
+const pluralize = require('pluralize')
+const Promise = require('es6-promise').Promise
+const deserialize = require('./middleware/json-api/_deserialize')
+const serialize = require('./middleware/json-api/_serialize')
 
 /*
 *   == JsonApiMiddleware
@@ -13,14 +13,14 @@ import serialize   from './middleware/json-api/_serialize'
 *   standards.
 *
 */
-import jsonApiPostMiddleware         from './middleware/json-api/req-post'
-import jsonApiPatchMiddleware        from './middleware/json-api/req-patch'
-import jsonApiDeleteMiddleware       from './middleware/json-api/req-delete'
-import jsonApiHeadersMiddleware      from './middleware/json-api/req-headers'
-import railsParamsSerializer         from './middleware/json-api/rails-params-serializer'
-import sendRequestMiddleware         from './middleware/request'
-import deserializeResponseMiddleware from './middleware/json-api/res-deserialize'
-import processErrors                 from './middleware/json-api/res-errors'
+const jsonApiPostMiddleware = require('./middleware/json-api/req-post')
+const jsonApiPatchMiddleware = require('./middleware/json-api/req-patch')
+const jsonApiDeleteMiddleware = require('./middleware/json-api/req-delete')
+const jsonApiHeadersMiddleware = require('./middleware/json-api/req-headers')
+const railsParamsSerializer = require('./middleware/json-api/rails-params-serializer')
+const sendRequestMiddleware = require('./middleware/request')
+const deserializeResponseMiddleware = require('./middleware/json-api/res-deserialize')
+const processErrors = require('./middleware/json-api/res-errors')
 
 let jsonApiMiddleware = [
   jsonApiPostMiddleware,
@@ -210,4 +210,4 @@ class JsonApi {
 
 }
 
-export default JsonApi
+module.exports = JsonApi

--- a/middleware/json-api/_deserialize.js
+++ b/middleware/json-api/_deserialize.js
@@ -1,5 +1,5 @@
-import _ from 'lodash'
-import pluralize from 'pluralize'
+const _ = require('lodash')
+const pluralize = require('pluralize')
 
 function collection(items, included) {
   return items.map(item => { return resource.call(this, item, included) })
@@ -98,7 +98,7 @@ function isRelatedItemFor(attribute, relatedItem, relationMapItem) {
   )
 }
 
-export default {
+module.exports = {
   resource: resource,
   collection: collection
 }

--- a/middleware/json-api/_serialize.js
+++ b/middleware/json-api/_serialize.js
@@ -1,5 +1,5 @@
-import _ from 'lodash'
-import pluralize from 'pluralize'
+const _ = require('lodash')
+const pluralize = require('pluralize')
 
 function collection(modelName, items) {
   return items.map(item => { return resource.call(this, modelName, item) })
@@ -70,7 +70,7 @@ function serializeHasOne(relationship, type) {
   }
 }
 
-export default {
+module.exports = {
   resource: resource,
   collection: collection
 }

--- a/middleware/json-api/rails-params-serializer.js
+++ b/middleware/json-api/rails-params-serializer.js
@@ -1,6 +1,6 @@
-import Qs from 'qs'
+const Qs = require('qs')
 
-export default {
+module.exports = {
   name: 'rails-params-serializer',
   req: (payload)=> {
     if(payload.req.method === 'GET') {

--- a/middleware/json-api/req-delete.js
+++ b/middleware/json-api/req-delete.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   name: 'DELETE',
   req: (payload)=> {
     if(payload.req.method === 'DELETE') {

--- a/middleware/json-api/req-headers.js
+++ b/middleware/json-api/req-headers.js
@@ -1,5 +1,6 @@
-import {isEmpty} from 'lodash'
-export default {
+const isEmpty = require('lodash').isEmpty
+
+module.exports = {
   name: 'HEADER',
   req: (payload)=> {
     if (!isEmpty(payload.jsonApi.headers)) {

--- a/middleware/json-api/req-patch.js
+++ b/middleware/json-api/req-patch.js
@@ -1,6 +1,6 @@
-import serialize from './_serialize'
+const serialize = require('./_serialize')
 
-export default {
+module.exports = {
   name: 'PATCH',
   req: (payload)=> {
     let jsonApi = payload.jsonApi

--- a/middleware/json-api/req-post.js
+++ b/middleware/json-api/req-post.js
@@ -1,6 +1,6 @@
-import serialize from './_serialize'
+const serialize = require('./_serialize')
 
-export default {
+module.exports = {
   name: 'POST',
   req: (payload)=> {
     let jsonApi = payload.jsonApi

--- a/middleware/json-api/res-deserialize.js
+++ b/middleware/json-api/res-deserialize.js
@@ -1,5 +1,5 @@
-import deserialize from './_deserialize'
-import _ from 'lodash'
+const deserialize = require('./_deserialize')
+const _ = require('lodash')
 
 function needsDeserialization(method) {
   return ['GET', 'PATCH', 'POST'].indexOf(method) !== -1
@@ -9,7 +9,7 @@ function isCollection(responseData) {
   return _.isArray(responseData)
 }
 
-export default {
+module.exports = {
   name: 'response',
   res: function(payload) {
     /*

--- a/middleware/json-api/res-errors.js
+++ b/middleware/json-api/res-errors.js
@@ -15,7 +15,7 @@ function errorKey(source) {
   return source.pointer.split('/').pop()
 }
 
-export default {
+module.exports = {
   name: 'errors',
   error: function(payload) {
     return buildErrors(payload.data)

--- a/middleware/request.js
+++ b/middleware/request.js
@@ -1,6 +1,6 @@
-import {Promise} from 'es6-promise'
+const Promise = require('es6-promise').Promise
 
-export default {
+module.exports = {
   name: 'axios-request',
   req: function(payload) {
     let jsonApi = payload.jsonApi

--- a/package.json
+++ b/package.json
@@ -17,10 +17,7 @@
     "API",
     "Client"
   ],
-  "author": [
-    "Emerson Lackey",
-    "Josh Zucker"
-  ],
+  "author": "",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/twg/devour-jsonapi-client/issues"
@@ -41,5 +38,31 @@
     "es6-promise": "^3.1.2",
     "lodash": "^4.11.2",
     "pluralize": "^1.2.1"
-  }
+  },
+  "gitHead": "90361305416393cc969a45f04d618b41eadf0d53",
+  "_id": "devour-jsonapi-client@1.0.1",
+  "_shasum": "99117da688b875831bc6fafe80d6fa8c1304bde5",
+  "_from": "devour-jsonapi-client@latest",
+  "_npmVersion": "3.3.12",
+  "_nodeVersion": "5.3.0",
+  "_npmUser": {
+    "name": "emerson",
+    "email": "emerson.lackey@gmail.com"
+  },
+  "dist": {
+    "shasum": "99117da688b875831bc6fafe80d6fa8c1304bde5",
+    "tarball": "https://registry.npmjs.org/devour-jsonapi-client/-/devour-jsonapi-client-1.0.1.tgz"
+  },
+  "maintainers": [
+    {
+      "name": "emerson",
+      "email": "emerson.lackey@gmail.com"
+    }
+  ],
+  "_npmOperationalInternal": {
+    "host": "packages-12-west.internal.npmjs.com",
+    "tmp": "tmp/devour-jsonapi-client-1.0.1.tgz_1462307440900_0.4206870866473764"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/devour-jsonapi-client/-/devour-jsonapi-client-1.0.1.tgz"
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "API",
     "Client"
   ],
-  "author": "",
+  "author": [
+    "Emerson Lackey",
+    "Josh Zucker"
+  ],
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/twg/devour-jsonapi-client/issues"
@@ -38,31 +41,5 @@
     "es6-promise": "^3.1.2",
     "lodash": "^4.11.2",
     "pluralize": "^1.2.1"
-  },
-  "gitHead": "90361305416393cc969a45f04d618b41eadf0d53",
-  "_id": "devour-jsonapi-client@1.0.1",
-  "_shasum": "99117da688b875831bc6fafe80d6fa8c1304bde5",
-  "_from": "devour-jsonapi-client@latest",
-  "_npmVersion": "3.3.12",
-  "_nodeVersion": "5.3.0",
-  "_npmUser": {
-    "name": "emerson",
-    "email": "emerson.lackey@gmail.com"
-  },
-  "dist": {
-    "shasum": "99117da688b875831bc6fafe80d6fa8c1304bde5",
-    "tarball": "https://registry.npmjs.org/devour-jsonapi-client/-/devour-jsonapi-client-1.0.1.tgz"
-  },
-  "maintainers": [
-    {
-      "name": "emerson",
-      "email": "emerson.lackey@gmail.com"
-    }
-  ],
-  "_npmOperationalInternal": {
-    "host": "packages-12-west.internal.npmjs.com",
-    "tmp": "tmp/devour-jsonapi-client-1.0.1.tgz_1462307440900_0.4206870866473764"
-  },
-  "directories": {},
-  "_resolved": "https://registry.npmjs.org/devour-jsonapi-client/-/devour-jsonapi-client-1.0.1.tgz"
+  }
 }


### PR DESCRIPTION
## Priority
High. This fix enables Devour to be brought into a project as a dependency via NPM.

## What Changed & Why
NPM/Node does not currently support ES6 style module syntax (`import`/`export`) (ref: https://github.com/nodejs/help/issues/53). When trying to include Devour as a dependancy, I was getting the following error: `unexpected token import`. To fix this issue, I changed Devour to use the Node.js style module syntax (`require`/`module.exports`).
