### PR TITLE
Removed singleton pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ While there are quite a few [JavaScript client implementations](http://jsonapi.o
 import JsonApi from 'devour-api-client'
 
 // Bootstrap
-let jsonApi = JsonApi.getInstance()
-jsonApi.setup('http://your-api-here.com')
+const jsonApi = new JsonApi('http://your-api-here.com')
 
 // Define Model
 jsonApi.define('post', {

--- a/index.js
+++ b/index.js
@@ -36,9 +36,9 @@ let jsonApiMiddleware = [
 
 class JsonApi {
 
-  constructor(apiUrl, middleware = jsonApiMiddleware.slice(0)) {
+  constructor(apiUrl, middleware = jsonApiMiddleware) {
     this._originalMiddleware = middleware.slice(0)
-    this.middleware = middleware
+    this.middleware = middleware.slice(0)
     this.headers = {}
     this.axios = axios
     this.apiUrl = apiUrl

--- a/index.js
+++ b/index.js
@@ -34,22 +34,9 @@ let jsonApiMiddleware = [
 ]
 
 
-/*
-*   We are creating a singleton, so we cache the reference to the instance
-*   outside our class closure and check it during instantiation.
-*/
-let instance = null
-
 class JsonApi {
 
-  static getInstance() {
-    if(!instance) {
-      instance = new JsonApi()
-    }
-    return instance
-  }
-
-  setup(apiUrl, middleware = jsonApiMiddleware) {
+  constructor(apiUrl, middleware = jsonApiMiddleware.slice(0)) {
     this._originalMiddleware = middleware.slice(0)
     this.middleware = middleware
     this.headers = {}

--- a/test/api/api-test.js
+++ b/test/api/api-test.js
@@ -2,33 +2,27 @@ import JsonApi from '../../index'
 import mockResponse from '../helpers/mock-response'
 import expect from 'expect.js'
 
-let Context = {
-  jsonApi: null
-}
-
 describe('JsonApi', ()=> {
 
+  var jsonApi = null
   beforeEach(()=> {
-    Context.jsonApi = JsonApi.getInstance()
-    Context.jsonApi.setup('http://myapi.com')
-    Context.jsonApi.resetMiddleware()
+    jsonApi = new JsonApi('http://myapi.com')
   })
 
   it('should set the apiUrl during setup', ()=> {
-    expect(Context.jsonApi.apiUrl).to.eql('http://myapi.com')
+    expect(jsonApi.apiUrl).to.eql('http://myapi.com')
   })
 
   it('should expose the serialize and deserialize objects', ()=> {
-    expect(Context.jsonApi.serialize.collection).to.be.a('function')
-    expect(Context.jsonApi.serialize.resource).to.be.a('function')
-    expect(Context.jsonApi.deserialize.collection).to.be.a('function')
-    expect(Context.jsonApi.deserialize.resource).to.be.a('function')
-
+    expect(jsonApi.serialize.collection).to.be.a('function')
+    expect(jsonApi.serialize.resource).to.be.a('function')
+    expect(jsonApi.deserialize.collection).to.be.a('function')
+    expect(jsonApi.deserialize.resource).to.be.a('function')
   })
 
   it('should have a empty models and middleware properties after instantiation', ()=> {
-    expect(Context.jsonApi.models).to.be.an('object')
-    expect(Context.jsonApi.middleware).to.be.an('array')
+    expect(jsonApi.models).to.be.an('object')
+    expect(jsonApi.middleware).to.be.an('array')
   })
 
   it('should allow users to register middleware', ()=> {
@@ -41,74 +35,74 @@ describe('JsonApi', ()=> {
         return res
       }
     }
-    Context.jsonApi.middleware.unshift(catMiddleWare)
-    expect(Context.jsonApi.middleware[0].name).to.eql('cat-middleware')
+    jsonApi.middleware.unshift(catMiddleWare)
+    expect(jsonApi.middleware[0].name).to.eql('cat-middleware')
   })
 
   it('should initialize with an empty headers object', ()=> {
-    expect(Context.jsonApi.headers).to.be.an('object')
-    expect(Context.jsonApi.headers).to.eql({})
+    expect(jsonApi.headers).to.be.an('object')
+    expect(jsonApi.headers).to.eql({})
   })
 
   it('should allow users to add headers', ()=> {
-    Context.jsonApi.headers['A-Header-Name'] = 'a value'
-    expect(Context.jsonApi.headers).to.eql({
+    jsonApi.headers['A-Header-Name'] = 'a value'
+    expect(jsonApi.headers).to.eql({
       'A-Header-Name':'a value'
     })
   })
 
   it('should allow users to register middleware before or after existing middleware', ()=> {
-    let responseMiddleware = Context.jsonApi.middleware.filter(middleware => middleware.name === 'response')[0]
+    let responseMiddleware = jsonApi.middleware.filter(middleware => middleware.name === 'response')[0]
     let beforeMiddleware = {
       name: 'before'
     }
     let afterMiddleware = {
       name: 'after'
     }
-    let index = Context.jsonApi.middleware.indexOf(responseMiddleware)
-    Context.jsonApi.insertMiddlewareBefore('response', beforeMiddleware)
-    Context.jsonApi.insertMiddlewareAfter('response', afterMiddleware)
-    expect(Context.jsonApi.middleware.indexOf(beforeMiddleware)).to.eql(index)
-    expect(Context.jsonApi.middleware.indexOf(afterMiddleware)).to.eql(index + 2)
+    let index = jsonApi.middleware.indexOf(responseMiddleware)
+    jsonApi.insertMiddlewareBefore('response', beforeMiddleware)
+    jsonApi.insertMiddlewareAfter('response', afterMiddleware)
+    expect(jsonApi.middleware.indexOf(beforeMiddleware)).to.eql(index)
+    expect(jsonApi.middleware.indexOf(afterMiddleware)).to.eql(index + 2)
   })
 
   it('should allow users to define models', ()=> {
-    Context.jsonApi.define('product', {
+    jsonApi.define('product', {
       id:    '',
       title: ''
     })
-    expect(Context.jsonApi.models['product']).to.be.an('object')
-    expect(Context.jsonApi.models['product']['attributes']).to.have.key('id')
-    expect(Context.jsonApi.models['product']['attributes']).to.have.key('title')
+    expect(jsonApi.models['product']).to.be.an('object')
+    expect(jsonApi.models['product']['attributes']).to.have.key('id')
+    expect(jsonApi.models['product']['attributes']).to.have.key('title')
   })
 
   it('should construct collection paths for models', ()=> {
-    Context.jsonApi.define('product', {})
-    expect(Context.jsonApi.collectionPathFor('product')).to.eql('products')
+    jsonApi.define('product', {})
+    expect(jsonApi.collectionPathFor('product')).to.eql('products')
   })
 
   it('should allow overrides for collection paths', ()=> {
-    Context.jsonApi.define('product', {}, {collectionPath: 'my-products'})
-    expect(Context.jsonApi.collectionPathFor('product')).to.eql('my-products')
+    jsonApi.define('product', {}, {collectionPath: 'my-products'})
+    expect(jsonApi.collectionPathFor('product')).to.eql('my-products')
   })
 
   it('should construct single resource paths for models', ()=> {
-    Context.jsonApi.define('product', {})
-    expect(Context.jsonApi.resourcePathFor('product', 1)).to.eql('products/1')
+    jsonApi.define('product', {})
+    expect(jsonApi.resourcePathFor('product', 1)).to.eql('products/1')
   })
 
   it('should construct collection urls for models', ()=> {
-    Context.jsonApi.define('product', {})
-    expect(Context.jsonApi.collectionUrlFor('product')).to.eql('http://myapi.com/products')
+    jsonApi.define('product', {})
+    expect(jsonApi.collectionUrlFor('product')).to.eql('http://myapi.com/products')
   })
 
   it('should construct single resource urls for models', ()=> {
-    Context.jsonApi.define('product', {})
-    expect(Context.jsonApi.resourceUrlFor('product', 1)).to.eql('http://myapi.com/products/1')
+    jsonApi.define('product', {})
+    expect(jsonApi.resourceUrlFor('product', 1)).to.eql('http://myapi.com/products/1')
   })
 
   it('should make basic find calls', (done)=> {
-    mockResponse(Context.jsonApi, {
+    mockResponse(jsonApi, {
       data: {
         data: {
           id: '1',
@@ -119,10 +113,10 @@ describe('JsonApi', ()=> {
         }
       }
     })
-    Context.jsonApi.define('product', {
+    jsonApi.define('product', {
       title: ''
     })
-    Context.jsonApi.find('product', 1).then((product)=> {
+    jsonApi.find('product', 1).then((product)=> {
       expect(product.id).to.eql('1')
       expect(product.title).to.eql('Some Title')
       done()
@@ -130,7 +124,7 @@ describe('JsonApi', ()=> {
   })
 
   it('should make basic findAll calls', (done)=> {
-    mockResponse(Context.jsonApi, {
+    mockResponse(jsonApi, {
       data: {
         data: [
           {
@@ -150,10 +144,10 @@ describe('JsonApi', ()=> {
         ]
       }
     })
-    Context.jsonApi.define('product', {
+    jsonApi.define('product', {
       title: ''
     })
-    Context.jsonApi.findAll('product').then((products)=> {
+    jsonApi.findAll('product').then((products)=> {
       expect(products[0].id).to.eql('1')
       expect(products[0].title).to.eql('Some Title')
       expect(products[1].id).to.eql('2')
@@ -163,7 +157,7 @@ describe('JsonApi', ()=> {
   })
 
   it('should include meta information on response objects', (done)=> {
-    mockResponse(Context.jsonApi, {
+    mockResponse(jsonApi, {
       data: {
         meta: {
           totalObjects: 1
@@ -177,10 +171,10 @@ describe('JsonApi', ()=> {
         }]
       }
     })
-    Context.jsonApi.define('product', {
+    jsonApi.define('product', {
       title: ''
     })
-    Context.jsonApi.findAll('product').then((products)=> {
+    jsonApi.findAll('product').then((products)=> {
       expect(products.meta.totalObjects).to.eql(1)
       expect(products[0].id).to.eql('1')
       expect(products[0].title).to.eql('Some Title')

--- a/test/api/deserialize-test.js
+++ b/test/api/deserialize-test.js
@@ -5,15 +5,12 @@ import expect from 'expect.js'
 
 describe('deserialize', ()=> {
 
-  afterEach(()=> {
-    let jsonApi = JsonApi.getInstance()
-    jsonApi.setup('http://myapi.com')
-    jsonApi.resetMiddleware()
+  var jsonApi = null
+  before(()=> {
+    jsonApi = new JsonApi('http://myapi.com')
   })
 
   it('should deserialize single resource items', ()=> {
-    let jsonApi = JsonApi.getInstance()
-    jsonApi.setup('http://myapi.com')
     jsonApi.define('product', {
       title: '',
       about: ''
@@ -35,8 +32,6 @@ describe('deserialize', ()=> {
   })
 
   it('should deserialize hasMany relations', ()=> {
-    let jsonApi = JsonApi.getInstance()
-    jsonApi.setup('http://myapi.com')
     jsonApi.define('product', {
       title: '',
       tags: {
@@ -85,8 +80,6 @@ describe('deserialize', ()=> {
   })
 
   it('should deserialize collections of resource items', ()=> {
-    let jsonApi = JsonApi.getInstance()
-    jsonApi.setup('http://myapi.com')
     jsonApi.define('product', {
       title: '',
       about: ''

--- a/test/api/serialize-test.js
+++ b/test/api/serialize-test.js
@@ -5,15 +5,12 @@ import expect from 'expect.js'
 
 describe('serialize', ()=> {
 
-  afterEach(()=> {
-    let jsonApi = JsonApi.getInstance()
-    jsonApi.setup('http://myapi.com')
-    jsonApi.resetMiddleware()
+  var jsonApi = null
+  beforeEach(()=> {
+    jsonApi = new JsonApi('http://myapi.com')
   })
 
   it('should serialize resource items', ()=> {
-    let jsonApi = JsonApi.getInstance()
-    jsonApi.setup('http://myapi.com')
     jsonApi.define('product', {
       title: '',
       about: ''
@@ -25,8 +22,6 @@ describe('serialize', ()=> {
   })
 
   it('should serialize hasMany relationships', ()=> {
-    let jsonApi = JsonApi.getInstance()
-    jsonApi.setup('http://myapi.com')
     jsonApi.define('product', {
       title: '',
       about: '',
@@ -57,8 +52,6 @@ describe('serialize', ()=> {
   })
 
   it('should serialize hasOne relationships', ()=> {
-    let jsonApi = JsonApi.getInstance()
-    jsonApi.setup('http://myapi.com')
     jsonApi.define('product', {
       title: '',
       about: '',
@@ -81,8 +74,6 @@ describe('serialize', ()=> {
   })
 
   it('should not serialize read only attributes', ()=> {
-    let jsonApi = JsonApi.getInstance()
-    jsonApi.setup('http://myapi.com')
     jsonApi.define('product', {
       title: '',
       about: '',
@@ -102,8 +93,6 @@ describe('serialize', ()=> {
   })
 
   it('should serialize collections of items', ()=> {
-    let jsonApi = JsonApi.getInstance()
-    jsonApi.setup('http://myapi.com')
     jsonApi.define('product', {
       title: '',
       about: ''
@@ -120,8 +109,6 @@ describe('serialize', ()=> {
   })
 
   it('should serialize the id of items if present', ()=> {
-    let jsonApi = JsonApi.getInstance()
-    jsonApi.setup('http://myapi.com')
     jsonApi.define('product', {title: ''})
     let serializedItem = serialize.resource.call(jsonApi, 'product', {id: '5', title: 'Hello'})
     expect(serializedItem.type).to.eql('products')
@@ -129,8 +116,6 @@ describe('serialize', ()=> {
   })
 
   it('should allow for custom serialization if present on the model', ()=> {
-    let jsonApi = JsonApi.getInstance()
-    jsonApi.setup('http://myapi.com')
     jsonApi.define('product', {title: ''}, {serializer: ()=> {
       return {
         custom: true

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--compilers js:babel-register
+--recursive

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,0 @@
---compilers js:babel-register
---recursive


### PR DESCRIPTION
This pull request addresses issue #5 by removing the singleton pattern in favour of creating instances with the `new` keyword, and using the ES6 `constructor` function on the `JsonApi` class.