### PR TITLE
Moved mocha options to test/mocha.opts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Don't just consume your JSON API, Devour it...",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --compilers js:babel-core/register test/**"
+    "test": "./node_modules/.bin/mocha"
   },
   "repository": {
     "type": "git",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--recursive
+--compilers js:babel-register


### PR DESCRIPTION
This pull request moves the mocha cli switches into `test/mocha.opts`, a standard location mocha looks for, and out of `package.json`'s test script definition. This allows us to run `mocha` from the command line with our own switches for more expressive testing, and DRYs up our `package.json`. 