### PR TITLE
disabled qs encoding

### DIFF
--- a/middleware/json-api/rails-params-serializer.js
+++ b/middleware/json-api/rails-params-serializer.js
@@ -5,7 +5,10 @@ module.exports = {
   req: (payload)=> {
     if(payload.req.method === 'GET') {
       payload.req.paramsSerializer = function(params) {
-        return Qs.stringify(params, {arrayFormat: 'brackets'})
+        return Qs.stringify(params, {
+          arrayFormat: 'brackets',
+          encode: false
+        })
       }
     }
 


### PR DESCRIPTION
## Priority
Medium. Prevents the construction of queries with more complicated/structured query params.

## What Changed & Why
Disabled qs URI encoding.

Before:
`api.find('match-result', '123', {filter: {status: 'fuzzy'}})` 
results in: `/api/match-results/123?filter%5Bstatus%5D=fuzzy`

After:
`api.find('match-result', '123', {filter: {status: 'fuzzy'}})`
results in `/api/match-results/123?filter[status]=fuzzy`
