### PR TITLE
improved error message when models do not match

### DIFF
--- a/middleware/json-api/_deserialize.js
+++ b/middleware/json-api/_deserialize.js
@@ -1,12 +1,14 @@
 const _ = require('lodash')
 const pluralize = require('pluralize')
 
-function collection(items, included) {
-  return items.map(item => { return resource.call(this, item, included) })
+function collection(items, included, responseModel) {
+  return items.map(item => { return resource.call(this, item, included, responseModel) })
 }
 
-function resource(item, included) {
+function resource(item, included, responseModel) {
   let model = this.modelFor(pluralize.singular(item.type))
+  if (!model) throw 'The JSON API response had a type of "' + item.type + '" but Devour expected the type to be "'+ responseModel +'".'
+
   let deserializedModel = {}
 
   if(item.id) {

--- a/middleware/json-api/res-deserialize.js
+++ b/middleware/json-api/res-deserialize.js
@@ -26,9 +26,9 @@ module.exports = {
 
     if(needsDeserialization(req.method)) {
       if(isCollection(res.data)) {
-        deserializedResponse = deserialize.collection.call(jsonApi, res.data, included)
+        deserializedResponse = deserialize.collection.call(jsonApi, res.data, included, req.model)
       }else{
-        deserializedResponse = deserialize.resource.call(jsonApi, res.data, included)
+        deserializedResponse = deserialize.resource.call(jsonApi, res.data, included, req.model)
       }
     }
 


### PR DESCRIPTION
## Priority
Low. This PR simply provides a more helpful error message when there is a misalignment defined amongst models.

## What Changed & Why
Previously when the JSON API type attribute didn't match the specified Devour model the error message did not provide much indication as to where the problem lay. It read: `TypeError: Cannot read property 'attributes' of undefined`.

Now, when the Devour model and JSON API type attribute do not align, Devour displays a more helpful error message that reads: `The JSON API response had a type of "match-result" but Devour expected the type to be "match-set".`.
